### PR TITLE
✨ Update autojump source path & code alias

### DIFF
--- a/aliases
+++ b/aliases
@@ -28,7 +28,7 @@ fi
 alias grepn='grep -n'
 alias grepr='grep -rnH'
 
-alias c='code'
+alias c='code-insiders'
 alias e='v'
 alias o='open'
 alias v='nvim'
@@ -167,8 +167,8 @@ alias plog='tail -f log/production.log'
 alias qlog='tail -f log/qa.log'
 alias slog='tail -f log/staging.log'
 alias tlog='tail -f log/test.log'
-alias rd:start='brew services run postgresql && brew services run redis'
-alias rd:stop='brew services stop postgresql && brew services stop redis'
+alias rd:start='brew services run postgresql@15 && brew services run redis'
+alias rd:stop='brew services stop postgresql@15 && brew services stop redis'
 
 
 test -e "${HOME}/.aliases.local" && source "${HOME}/.aliases.local"

--- a/bashrc
+++ b/bashrc
@@ -10,7 +10,7 @@ export EDITOR='vim'
 export FZF_DEFAULT_COMMAND='rg --files --hidden --no-ignore-vcs'
 
 [[ -s $HOME/.cargo/env ]] && source $HOME/.cargo/env
-[[ -s /usr/local/etc/profile.d/autojump.sh ]] && source /usr/local/etc/profile.d/autojump.sh
+[[ -s /opt/homebrew/etc/profile.d/autojump.sh ]] && source /opt/homebrew/etc/profile.d/autojump.sh
 
 [[ -s $HOME/.bashrc.local ]] && source $HOME/.bashrc.local
 


### PR DESCRIPTION
Updated the autojump source path to use the new Homebrew directory.
Changed 'c' alias to point to 'code-insiders' instead of 'code'.