### PR TITLE
Add new configuration for Ghostty

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -25,9 +25,9 @@ palette = 13=#C678DD
 palette = 14=#56B6C2
 palette = 15=#FFFFFF
 
-background = 1E2127
-foreground = ABB2BF
-cursor-color = FFFFFF
+background = #1E2127
+foreground = #ABB2BF
+cursor-color = #FFFFFF
 
-selection-background = 3A3F4B
-selection-foreground = ABB2BF
+selection-background = #3A3F4B
+selection-foreground = #ABB2BF

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,0 +1,33 @@
+window-save-state = always
+font-size = 20
+font-family = "Hack Nerd Font Mono"
+
+macos-titlebar-style = transparent
+window-colorspace = display-p3
+shell-integration-features = sudo,title
+
+# based on https://github.com/nathanbuchar/atom-one-dark-terminal
+
+palette = 0=#1E2127
+palette = 1=#E06C75
+palette = 2=#98C379
+palette = 3=#D19A66
+palette = 4=#61AFEF
+palette = 5=#C678DD
+palette = 6=#56B6C2
+palette = 7=#ABB2BF
+palette = 8=#5C6370
+palette = 9=#E06C75
+palette = 10=#98C379
+palette = 11=#D19A66
+palette = 12=#61AFEF
+palette = 13=#C678DD
+palette = 14=#56B6C2
+palette = 15=#FFFFFF
+
+background = 1E2127
+foreground = ABB2BF
+cursor-color = FFFFFF
+
+selection-background = 3A3F4B
+selection-foreground = ABB2BF


### PR DESCRIPTION
- Added a new configuration file for the Ghostty terminal emulator
- Set the window save state, font size and family, macOS titlebar style, window colorspace, and shell integration features
- Defined a custom color palette based on the Atom One Dark theme, including background, foreground, cursor, selection background, and selection foreground colors